### PR TITLE
Enhanced encoding of non-Chinese characters in Markdown links

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,11 @@ import { App, Modal, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian'
 import { MarkdownView, TFile } from 'obsidian'
 
 export default class WikilinksToMdlinks extends Plugin {
+
+	encodeNonChinese(str: string) {
+        return Array.from(str).map(ch => ch.match(/[\u4e00-\u9fa5]/) ? ch : encodeURIComponent(ch)).join('');
+    }
+
 	onload() {
 		console.log('loading wikilinks-to-mdlinks plugin...')
 
@@ -77,8 +82,8 @@ export default class WikilinksToMdlinks extends Plugin {
 					} else {
 						newText = newText + ".md"
 					}
-					const encodedText = encodeURI(newText)
-					let newItem = `[${text}](${encodedText})`
+					let encodedText = this.encodeNonChinese(newText);
+					let newItem = `[${text}](${encodedText})`;
 
 					const cursorStart = {
 						line: cursor.line,


### PR DESCRIPTION
Hello,

This PR introduces changes to the `wikilinks-to-mdlinks` plugin. The main purpose of these changes is to improve the encoding of non-Chinese characters in Markdown links.

Changes include:
- The addition of the `encodeNonChinese` function, which encodes all non-Chinese characters in a string, and should resolve issue #13.
- The modification of the `toggleLink` function to use `encodeNonChinese` for encoding non-Chinese characters in Markdown links.

These changes ensure that non-Chinese characters in Markdown links are properly encoded. This prevents any potential issues that might arise from improperly encoded characters in Markdown links.

I want to note that these changes were made with the help of the chatGPT AI developed by OpenAI. I am a C++ developer and not familiar with JavaScript. I have tested these changes by installing the plugin and modifying the main.js file, and it worked as expected (I will attach the modified main.js file and the actual effect screenshot). However, I have not compiled or thoroughly tested the changes in a development environment.

I apologize for not being able to fully test these changes, and I understand if that creates extra work on your end. I appreciate your understanding and help with testing these changes.

Please let me know if there are any questions or if further changes are needed.



Best Regards,
陈添梁

[main.js](https://image-1257198410.cos.na-siliconvalley.myqcloud.com/main.js)


![before.gif](https://image-1257198410.cos.na-siliconvalley.myqcloud.com/image/before.gif)

![after.gif](https://image-1257198410.cos.na-siliconvalley.myqcloud.com/image/after.gif)
