### PR TITLE
Fixed markdown links to consist only of basename when converting from wiki link to markdown link

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -78,7 +78,7 @@ export default class WikilinksToMdlinks extends Plugin {
 						newText = newText + ".md"
 					}
 					const encodedText = encodeURI(newText)
-					let newItem = `[${text}](${encodedText})`
+					let newItem = `[${text}](<${basename(encodedText)}>)`
 
 					const cursorStart = {
 						line: cursor.line,


### PR DESCRIPTION
Fixed markdown links to consist only of basename when converting from wiki link to markdown link

ウィキのリンクからマークダウンのリンクに変換する際、マークダウンのリンクがベースネームのみで構成されるように修正